### PR TITLE
Use typescript-eslint/indent

### DIFF
--- a/packages/typescript/index.js
+++ b/packages/typescript/index.js
@@ -15,6 +15,8 @@ module.exports = {
         "@typescript-eslint/no-shadow": "warn",
         "no-use-before-define": "off",
         "@typescript-eslint/no-use-before-define": ["warn", { "functions": false, "classes": true, "variables": false }],
+        "indent": "off",
+        "@typescript-eslint/indent": ["warn"],
         "@typescript-eslint/member-delimiter-style": ["warn"],
         "@typescript-eslint/consistent-type-definitions": ["warn"],
         "@typescript-eslint/no-implicit-any-catch": ["warn"],


### PR DESCRIPTION
Vise à adresser cet issue: https://github.com/eslint/eslint/issues/13956. 

Le symptôme dans VS Code est qu'à chaque fois que `const` est écrit, cette erreur est affichée: 
![image](https://user-images.githubusercontent.com/10562856/115594554-df9e6200-a2a3-11eb-9e25-bc6d1aa83ad2.png)


Remplace la règle par default `Indent` par la règle  `@typescript-eslint/eslint-plugin`