### PR TITLE
Fix Nextjs name in copy + Add ESLint 8 in peerDependencies

### DIFF
--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -1,6 +1,6 @@
 # eslint-config-nextjs
 
-Sharegate Next.js ESLint config.
+Sharegate Nextjs ESLint config.
 
 ## License
 

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sharegate/eslint-config-nextjs",
     "version": "1.0.0",
-    "description": "Sharegate Next.js ESLint config.",
+    "description": "Sharegate Nextjs ESLint config.",
     "repository": "https://github.com/gsoft-inc/sg-eslint",
     "author": "Groupe Sharegate inc.",
     "license": "Apache-2.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,7 +11,7 @@
     },
     "peerDependencies": {
         "@babel/eslint-parser": "*",
-        "eslint": "^6 || ^7"
+        "eslint": "^6 || ^7 || ^8"
     },
     "dependencies": {
         "@sharegate/eslint-config-recommended": "*",

--- a/packages/recommended/package.json
+++ b/packages/recommended/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "peerDependencies": {
-        "eslint": "^6 || ^7"
+        "eslint": "^6 || ^7 || ^8"
     },
     "dependencies": {
         "eslint-plugin-import": "*"

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -12,7 +12,7 @@
         "requireindex": "1.2.0"
     },
     "peerDependencies": {
-        "eslint": "^6 || ^7"
+        "eslint": "^6 || ^7 || ^8"
     },
     "engines": {
         "node": ">=0.10.0"

--- a/packages/sort-imports/package.json
+++ b/packages/sort-imports/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "peerDependencies": {
-        "eslint": "^6 || ^7"
+        "eslint": "^6 || ^7 || ^8"
     },
     "dependencies": {
         "eslint-plugin-sort-imports-es6-autofix": "*"

--- a/packages/strict/package.json
+++ b/packages/strict/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "peerDependencies": {
-        "eslint": "^6 || ^7"
+        "eslint": "^6 || ^7 || ^8"
     },
     "dependencies": {
         "@sharegate/eslint-plugin-rules": "1.3.2",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -11,7 +11,7 @@
     },
     "peerDependencies": {
         "@typescript-eslint/parser": "*",
-        "eslint": "^6 || ^7"
+        "eslint": "^6 || ^7 || ^8"
     },
     "dependencies": {
         "@sharegate/eslint-config-recommended": "*",


### PR DESCRIPTION
Fix the name "Next.js", replaced by Nextjs in the nextjs package.
Add ESLint in peerDependencies for `react` `recommended` `rules` `sort-imports` `strict` and `typescript`