### PR TITLE
Remove the .json rule to allow for a release

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
   "version": "independent",
   "command": {
     "version": {
-        "ignoreChanges": ["**/*.md", "**/*.json", "**/*.config.js", "**/*rc*"]
+        "ignoreChanges": ["**/*.md", "**/*.config.js", "**/*rc*"]
     }
   }
 }


### PR DESCRIPTION
Don't do this at home: Remove the .json rule to allow for a release of package.json