### PR TITLE
Add new linting rules 

### DIFF
--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -53,7 +53,7 @@ module.exports = {
         "react/no-array-index-key": "warn",
         "react/no-access-state-in-setstate": "warn",
         "react/jsx-filename-extension": "warn",
-        "react/jsx-tag-spacing": "warn",
+        "react/jsx-tag-spacing": ["warn", { beforeSelfClosing: "always" }],
         "react/jsx-curly-brace-presence": "warn",
         "react/jsx-max-props-per-line": [
             "warn",
@@ -63,6 +63,7 @@ module.exports = {
             "warn",
             { customValidators: [], skipShapeProps: true }
         ],
+        "react/jsx-curly-spacing": ["warn", { children: true, when: "never" }],
 
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules
         "jsx-a11y/accessible-emoji": "warn",

--- a/packages/recommended/index.js
+++ b/packages/recommended/index.js
@@ -141,11 +141,21 @@ module.exports = {
         "no-restricted-properties": "warn",
         "no-unneeded-ternary": "warn",
         "no-param-reassign": "warn",
+        "no-duplicate-imports": "warn",
+        "comma-spacing": ["warn", { "before": false, "after": true }],
+        "no-multiple-empty-lines": "warn",
+        "keyword-spacing": ["warn", { before: true, after: true }],
+        "arrow-spacing": ["warn", { before: true, after: true }],
+        "space-before-blocks": ["warn", "always"],
+        "space-infix-ops": "warn",
+        "space-in-parens": ["warn", "never"],
+        "padded-blocks": ["warn", "never"],
+        "brace-style":["warn", "1tbs", { "allowSingleLine": true }],
 
         // https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules
         "import/no-amd": "error",
         "import/no-webpack-loader-syntax": "error",
         "import/no-self-import": "error",
-        "import/newline-after-import" : "warn",
+        "import/newline-after-import" : "warn"
     }
 };

--- a/packages/typescript/index.js
+++ b/packages/typescript/index.js
@@ -64,14 +64,6 @@ module.exports = {
         "no-unused-vars":"off",
         "@typescript-eslint/no-unused-vars":"warn",
         "no-use-before-define":"off",
-        "@typescript-eslint/no-use-before-define": [
-            "warn",
-            {
-                functions: false,
-                classes: false,
-                variables: false
-            }
-        ],
         "no-useless-constructor":"off",
         "@typescript-eslint/no-useless-constructor":"warn",
         "object-curly-spacing":"off",
@@ -79,6 +71,7 @@ module.exports = {
         "quotes":"off",
         "@typescript-eslint/quotes": ["warn", "double"],
         "semi":"off",
-        "@typescript-eslint/semi": ["warn", "always"]
+        "@typescript-eslint/semi": ["warn", "always"],
+        "@typescript-eslint/no-non-null-assertion": "off"
     }
 };


### PR DESCRIPTION
It's been a while since we updated our shared ESlint configs. Over the years, we've added a lot of new rules in all the codebase, but never updated the shared packages.

Heres a list of rules already in all 5 code bases (except orbit) that I will add to the shared packages:
:heavy_plus_sign: recommended
no-duplicate-imports
comma-spacing -> ["warn", { "before": false, "after": true}]
no-multiple-empty-lines
keyword-spacing -> ["warn", { before: true, after: true }]
arrow-spacing -> ["warn", { before: true, after: true }],
space-before-blocks -> ["warn", "always"]
space-infix-ops
space-in-parens -> ["warn", "never"]
padded-blocks -> ["warn", "never"]

:heavy_plus_sign: react
react/jsx-curly-spacing -> ["warn", { children: true, when: "never" }]
react/jsx-tag-spacing -> ["warn", { beforeSelfClosing: "always" }]

Here is a list of rules that is in some codebases that I would promote as well:
:heavy_plus_sign: recommended
brace-style -> config  ["warn", "1tbs", { "allowSingleLine": true }]

Here is a list of rules that I would remove from the shared config, since we disable them in most apps:
:heavy_minus_sign: typescript
 @typescript-eslint/no-use-before-define -> causes error if we create a sub component at the bottom of a file. Creates lots of error and there is no real gain of using this.
@typescript-eslint/no-non-null-assertion -> We frequently use the ! operator, so might as well disable it in the config.

Is everyone alright with that? brace-style will cause error in your codebases, but it's for the best I think and should easily be auto-fixed.

Is there more rules we should add? or remove?